### PR TITLE
fix CercubePlus version

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -89,7 +89,7 @@
       "beta": false,
       "bundleIdentifier": "com.google.ios.youtubecercube",
       "developerName": "Alfhaily & Qn_",
-      "downloadURL": "https://github.com/qnblackcat/CercubePlus/releases/download/v17.36.3-5.3.11/CercubePlus_17.36.3_5.3.11.ipa",
+      "downloadURL": "https://github.com/qnblackcat/CercubePlus/releases/download/v17.35.3-5.3.11/CercubePlus_17.35.3_5.3.11.ipa",
       "iconURL": "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/youtube-512.png",
       "localizedDescription": "Unfortunately, AltStore can not handle two applications that have the same bundle ID (uYou+ and Cercube+). I have no other choice except to modify CercubePlus's bundle ID. As a result, you won't be able to install CercubePlus directly through AltStore. You still can download the IPA like normal though.\n\nFull infomation about CercubePlus (Cercube+) is available on my Github: https://github.com/qnblackcat/CercubePlus/\n\nCredits: Please keep the Credits if you re-up CercubePlus! \n- Alfhaily for Cercube.\n- Galactic-Dev for the original iSponsorBlock, @Luewii for his fork of iSponsorBlock (which works in jailed mode).\n- PoomSmart for YouRememberCaption, YTClassicVideoQuality, YTNoCheckLocalNetwork, YTSystemAppearance, YTUHD, YouPiP and Return YouTube Dislike.\n- level3tjg for YTNoHoverCards.\n\nKnown issues:\n- Hide Cast button may not work.\n- YTUHD: Stuttering on 2K/4K videos.\n- YouPiP (iOS 14.0 - 14.4.2): due to Apple's fault, you may encounter the speedup-bug as described here. The bug also happens when you try to play multi-sources of sound at the same time. Enable Legacy PiP is a workaround. Note that Legacy PiP removes UHD quality and breaks the default video quality feature of uYou. Use it at your own risk!",
       "name": "CercubePlus (Cercube+)",
@@ -103,9 +103,9 @@
       "size": 101187584,
       "subtitle": "Cercube with extra features! Requires iOS 13.0 and later.",
       "tintColor": "e22a41",
-      "version": "17.36.3",
+      "version": "17.35.3",
       "versionDate": "2022-09-12T14:00:00-01:00",
-      "versionDescription": "v17.36.3 (5.3.11): The changelog can be found at\nhttps://github.com/qnblackcat/CercubePlus/releases/latest"
+      "versionDescription": "v17.35.3 (5.3.11): The changelog can be found at\nhttps://github.com/qnblackcat/CercubePlus/releases/latest"
     },
     {
       "beta": false,


### PR DESCRIPTION
it was called 17.36.3 but the [latest released version](https://github.com/qnblackcat/CercubePlus/releases) is 17.35.3