### PR TITLE
Fix uYou+ Update Loop In 17.49.6 / 17.49.7

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -102,7 +102,7 @@
       "size": 116059757,
       "subtitle": "A modified version of uYou with extra features! Requires iOS 14.0 and later.",
       "tintColor": "e85567",
-      "version": "17.49.7",
+      "version": "17.49.6",
       "versionDate": "2022-12-12T12:00:00-01:00",
       "versionDescription": "v17.49.6 (2.3~1): The changelog can be found at\nhttps://github.com/qnblackcat/uYouPlus/releases/latest"
     }


### PR DESCRIPTION
- Changes uYou+ version **number** to 17.49.6.
- Addresses issue, https://github.com/qnblackcat/AltStore/issues/12 .