### PR TITLE
Update uYou+ to v18.14.1-3.0

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -66,7 +66,7 @@
       "beta": false,
       "bundleIdentifier": "com.google.ios.youtube",
       "developerName": "MiRO92 & Qn_",
-      "downloadURL": "https://github.com/qnblackcat/uYouPlus/releases/download/v18.08.1-2.3.1/uYouPlus_18.08.1_2.3.1.ipa",
+      "downloadURL": "https://github.com/qnblackcat/uYouPlus/releases/download/v18.15.1-3.0/uYouPlus_18.15.1_3.0.ipa",
       "iconURL": "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/icon_clipped.png",
       "localizedDescription": "uYouPlus is a modified version of uYou with some extra features! (requires iOS 14.0 and later).\n\nFull infomation about uYouPlus (uYou+) is available on my Github: https://github.com/qnblackcat/uYouPlus/\n\nCredits: Please keep the Credits if you re-up uYouPlus! \nhttps://github.com/qnblackcat/uYouPlus#credits\n\nAttention:\n- If you like the app, considering support the developers!\n- YTUHD is not stable atm. You might encounter stuttering, heat, battery drain..., especially when playing at 2160p (4K) quality. However, this should not happen if you use TrollStore.\n- Unless you're using TrollStore, deep-link (aka Open in the YouTube App) simply will not work.\n\nKnown issues:\n- uYou's issues: https://github.com/MiRO92/uYou-for-YouTube/issues\n- uYouPlus's issues: https://github.com/qnblackcat/uYouPlus",
       "name": "uYouPlus (uYou+)",
@@ -77,12 +77,12 @@
         "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/IMG_1523.PNG",
         "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/IMG_2395.PNG"
       ],
-      "size": 111605847,
+      "size": 124074764,
       "subtitle": "A modified version of uYou with extra features! Requires iOS 14.0 and later.",
       "tintColor": "e85567",
-      "version": "18.08.1",
-      "versionDate": "2023-02-28T12:00:00-01:00",
-      "versionDescription": "v18.08.1 (2.3~1): The changelog can be found at\nhttps://github.com/qnblackcat/uYouPlus/releases/latest"
+      "version": "18.15.1",
+      "versionDate": "2023-4-17T12:00:00-01:00",
+      "versionDescription": "v18.15.1 (3.0): The changelog can be found at\nhttps://github.com/qnblackcat/uYouPlus/releases/tag/v18.15.1-3.0"
     }
   ],
   "identifier": "com.qn.altstorerepo",

--- a/apps.json
+++ b/apps.json
@@ -66,7 +66,7 @@
       "beta": false,
       "bundleIdentifier": "com.google.ios.youtube",
       "developerName": "MiRO92 & Qn_",
-      "downloadURL": "https://github.com/qnblackcat/uYouPlus/releases/download/v18.15.1-3.0/uYouPlus_18.15.1_3.0.ipa",
+      "downloadURL": "https://github.com/qnblackcat/uYouPlus/releases/download/v18.14.1-3.0/uYouPlus_18.14.1_3.0.ipa",
       "iconURL": "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/icon_clipped.png",
       "localizedDescription": "uYouPlus is a modified version of uYou with some extra features! (requires iOS 14.0 and later).\n\nFull infomation about uYouPlus (uYou+) is available on my Github: https://github.com/qnblackcat/uYouPlus/\n\nCredits: Please keep the Credits if you re-up uYouPlus! \nhttps://github.com/qnblackcat/uYouPlus#credits\n\nAttention:\n- If you like the app, considering support the developers!\n- YTUHD is not stable atm. You might encounter stuttering, heat, battery drain..., especially when playing at 2160p (4K) quality. However, this should not happen if you use TrollStore.\n- Unless you're using TrollStore, deep-link (aka Open in the YouTube App) simply will not work.\n\nKnown issues:\n- uYou's issues: https://github.com/MiRO92/uYou-for-YouTube/issues\n- uYouPlus's issues: https://github.com/qnblackcat/uYouPlus",
       "name": "uYouPlus (uYou+)",
@@ -77,12 +77,12 @@
         "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/IMG_1523.PNG",
         "https://raw.githubusercontent.com/qnblackcat/My-AltStore-repo/main/ScreenShot/IMG_2395.PNG"
       ],
-      "size": 124074764,
+      "size": 123882320,
       "subtitle": "A modified version of uYou with extra features! Requires iOS 14.0 and later.",
       "tintColor": "e85567",
-      "version": "18.15.1",
-      "versionDate": "2023-4-17T12:00:00-01:00",
-      "versionDescription": "v18.15.1 (3.0): The changelog can be found at\nhttps://github.com/qnblackcat/uYouPlus/releases/tag/v18.15.1-3.0"
+      "version": "18.14.1",
+      "versionDate": "2023-4-27T12:00:00-01:00",
+      "versionDescription": "v18.14.1 (3.0): The changelog can be found at\nhttps://github.com/qnblackcat/uYouPlus/releases/tag/latest"
     }
   ],
   "identifier": "com.qn.altstorerepo",


### PR DESCRIPTION
I don't know if you want to keep the AltStore repo up to date with the pre's or not, but here is is if u want to, I also had to change the changelog link sense "/latest" goes to the one marked latest and the pre's don't get marked that way, another alternative, is we could make two apps, "uYou+" and then like "uYou+ (Pre-Release)".